### PR TITLE
Add Makefile and fix strtrim compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+COBC=cobc
+SRCS=$(wildcard *.cob)
+EXEC=library.so
+
+all: $(EXEC)
+
+$(EXEC): $(SRCS)
+	$(COBC) -b -o $@ $^
+
+clean:
+	rm -f *.o
+
+fclean: clean
+	rm -f $(EXEC)
+
+re: fclean all
+
+.PHONY: all clean fclean re

--- a/strtrim.cob
+++ b/strtrim.cob
@@ -23,9 +23,9 @@
            PERFORM UNTIL WS-START > WS-END
                MOVE LS-STRTRIM-SRC(WS-START:1) TO WS-CHAR
                IF WS-CHAR = WS-SPACE OR
-            -  WS-CHAR = WS-TAB OR
-            -  WS-CHAR = WS-LF OR
-            -  WS-CHAR = WS-CR
+                  WS-CHAR = WS-TAB OR
+                  WS-CHAR = WS-LF OR
+                  WS-CHAR = WS-CR
                    ADD 1 TO WS-START
                ELSE
                    EXIT PERFORM
@@ -35,9 +35,9 @@
            PERFORM UNTIL WS-END < WS-START
                MOVE LS-STRTRIM-SRC(WS-END:1) TO WS-CHAR
                IF WS-CHAR = WS-SPACE OR
-            -  WS-CHAR = WS-TAB OR
-            -  WS-CHAR = WS-LF OR
-            -  WS-CHAR = WS-CR
+                  WS-CHAR = WS-TAB OR
+                  WS-CHAR = WS-LF OR
+                  WS-CHAR = WS-CR
                    SUBTRACT 1 FROM WS-END
                ELSE
                    EXIT PERFORM


### PR DESCRIPTION
## Summary
- add a Makefile to build the COBOL library using `cobc`
- fix `strtrim.cob` conditional lines so it compiles

## Testing
- `make clean`
- `make`
- `make fclean`
- `make re`


------
https://chatgpt.com/codex/tasks/task_e_687297a215d48331b78725127df33cd3