### PR TITLE
Add sample main and test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,25 @@
 COBC=cobc
-SRCS=$(wildcard *.cob)
+SRCS=$(filter-out main.cob,$(wildcard *.cob))
 EXEC=library.so
+TEST_EXEC=test_program
 
 all: $(EXEC)
+
+test: $(TEST_EXEC)
+
+$(TEST_EXEC): main.cob $(SRCS)
+	$(COBC) -x -o $@ $^
 
 $(EXEC): $(SRCS)
 	$(COBC) -b -o $@ $^
 
 clean:
-	rm -f *.o
+	rm -f *.o $(TEST_EXEC)
 
 fclean: clean
 	rm -f $(EXEC)
 
 re: fclean all
 
-.PHONY: all clean fclean re
+.PHONY: all clean fclean re test
+

--- a/main.cob
+++ b/main.cob
@@ -1,0 +1,27 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. MAIN.
+
+       ENVIRONMENT DIVISION.
+
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-STR       PIC X(255).
+       01  WS-LEN       PIC 9(9) COMP-5.
+
+       PROCEDURE DIVISION.
+           DISPLAY "Running Cobol-Lib tests".
+
+           MOVE "   Hello COBOL   " TO WS-STR
+           DISPLAY "Before trim: '" WS-STR "'"
+           CALL 'STRTRIM' USING WS-STR
+           DISPLAY "After trim:  '" WS-STR "'"
+
+           MOVE "Hello" TO WS-STR
+           CALL 'STRLEN' USING WS-STR WS-LEN
+           DISPLAY "Length of 'Hello' is " WS-LEN
+
+           CALL 'STRCMP' USING WS-STR WS-STR
+           DISPLAY "STRCMP called (result unused)"
+
+           STOP RUN.
+       END PROGRAM MAIN.


### PR DESCRIPTION
## Summary
- add a simple `main.cob` to exercise existing COBOL routines
- extend Makefile with `test` target to build an executable

## Testing
- `make test` *(fails: `cobc: No such file or directory`)*
- `make` *(fails: `cobc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68729fd2c6dc833187676a0f6019ecee