### PR TITLE
Fix STRCMP parameter usage

### DIFF
--- a/main.cob
+++ b/main.cob
@@ -5,19 +5,23 @@
 
        DATA DIVISION.
        WORKING-STORAGE SECTION.
-       01  WS-STR       PIC X(255).
-       01  WS-LEN       PIC 9(9) COMP-5.
+        01  WS-STR       PIC X(255).
+        01  WS-LEN       PIC 9(9) COMP-5.
+        01  WS-CMP-RET   PIC 9(9) COMP-5.
 
        PROCEDURE DIVISION.
            DISPLAY "Running Cobol-Lib tests".
 
            MOVE "   Hello COBOL   " TO WS-STR
            DISPLAY "Before trim: '" WS-STR "'"
-           CALL 'STRTRIM' USING WS-STR
-           DISPLAY "After trim:  '" WS-STR "'"
+            CALL 'STRTRIM' USING WS-STR
+            DISPLAY "After trim:  '" WS-STR "'"
 
-           CALL 'STRCMP' USING WS-STR WS-STR WS-LEN WS-LEN
-           DISPLAY "STRCMP called (result unused)"
+            CALL 'STRLEN' USING WS-STR WS-LEN
+            DISPLAY "Length of trimmed string is " WS-LEN
+
+            CALL 'STRCMP' USING WS-CMP-RET WS-STR WS-STR WS-LEN WS-LEN
+            DISPLAY "STRCMP result: " WS-CMP-RET
 
            STOP RUN.
        END PROGRAM MAIN.

--- a/strcmp.cob
+++ b/strcmp.cob
@@ -14,8 +14,9 @@
        01  LS-STRCMP-SRC2          PIC X(255).
        01  LS-STRCMP-SRC2-LENGTH   PIC 9(5) COMP-5.
 
-       PROCEDURE DIVISION USING LS-STRCMP-SRC1 LS-STRCMP-SRC2
-           LS-STRCMP-SRC1-LENGTH LS-STRCMP-SRC2-LENGTH.
+       PROCEDURE DIVISION USING LS-STRCMP-RETURN
+       LS-STRCMP-SRC1 LS-STRCMP-SRC2
+       LS-STRCMP-SRC1-LENGTH LS-STRCMP-SRC2-LENGTH.
            MOVE 1 TO WS-INDEX
            MOVE 0 TO LS-STRCMP-RETURN
 
@@ -33,15 +34,15 @@
                END-IF
                ADD 1 TO WS-INDEX
            END-PERFORM
-           IF FUNCTION LENGTH(LS-STRCMP-SRC1) IS GREATER THAN
-               -    FUNCTION LENGTH(LS-STRCMP-SRC2)
-               MOVE 1 TO LS-STRCMP-RETURN
-           ELSE
-               IF FUNCTION LENGTH(LS-STRCMP-SRC1) IS LESS THAN
-                   -    FUNCTION LENGTH(LS-STRCMP-SRC2)
-                   MOVE -1 TO LS-STRCMP-RETURN
-               ELSE
-                   MOVE 0 TO LS-STRCMP-RETURN
-               END-IF
-           END-IF
-           GOBACK.
+            IF LS-STRCMP-SRC1-LENGTH IS GREATER THAN
+                LS-STRCMP-SRC2-LENGTH
+                MOVE 1 TO LS-STRCMP-RETURN
+            ELSE
+                IF LS-STRCMP-SRC1-LENGTH IS LESS THAN
+                    LS-STRCMP-SRC2-LENGTH
+                    MOVE -1 TO LS-STRCMP-RETURN
+                ELSE
+                    MOVE 0 TO LS-STRCMP-RETURN
+                END-IF
+            END-IF
+            GOBACK.


### PR DESCRIPTION
## Summary
- add a return value parameter to `STRCMP`
- compute string length before calling `STRCMP`
- display the comparison result

## Testing
- `make test`
- `valgrind ./test_program`

------
https://chatgpt.com/codex/tasks/task_e_6872b4be20b08331a125288aaea98a23