### PR TITLE
Fix Cobol test build

### DIFF
--- a/main.cob
+++ b/main.cob
@@ -5,24 +5,37 @@
 
        DATA DIVISION.
        WORKING-STORAGE SECTION.
-        01  WS-STR       PIC X(255).
-        01  WS-LEN       PIC 9(9) COMP-5.
-        01  WS-CMP-RET   PIC 9(9) COMP-5.
+       01  WS-STR       PIC X(255).
+       01  WS-LEN       PIC 9(9) COMP-5.
+       01  WS-CMP-RET   PIC S9(9) COMP-5.
+       01  WS-STR2      PIC X(255).
+       01  WS-LEN2      PIC 9(9) COMP-5.
 
        PROCEDURE DIVISION.
-           DISPLAY "Running Cobol-Lib tests".
-           END-DISPLAY.
+            DISPLAY "Running Cobol-Lib tests"
+            END-DISPLAY
 
-           MOVE "   Hello COBOL   " TO WS-STR
-           DISPLAY "Before trim: '" WS-STR "'"
+            MOVE "   Hello COBOL   " TO WS-STR
+            DISPLAY "Before trim: '" WS-STR "'"
+            END-DISPLAY
             CALL 'STRTRIM' USING WS-STR
+            END-CALL
             DISPLAY "After trim:  '" WS-STR "'"
+            END-DISPLAY
+
+            MOVE WS-STR TO WS-STR2
 
             CALL 'STRLEN' USING WS-STR WS-LEN
+            END-CALL
             DISPLAY "Length of trimmed string is " WS-LEN
+            END-DISPLAY
 
-            CALL 'STRCMP' USING WS-CMP-RET WS-STR WS-STR WS-LEN WS-LEN
+            MOVE WS-LEN TO WS-LEN2
+
+            CALL 'STRCMP' USING WS-CMP-RET WS-STR WS-STR2 WS-LEN WS-LEN2
+            END-CALL
             DISPLAY "STRCMP result: " WS-CMP-RET
+            END-DISPLAY
 
            STOP RUN.
        END PROGRAM MAIN.

--- a/strcmp.cob
+++ b/strcmp.cob
@@ -8,7 +8,7 @@
        01  WS-INDEX           PIC 9(9) COMP-5.
 
        LINKAGE SECTION.
-       01  LS-STRCMP-RETURN        PIC 9(9) COMP-5.
+       01  LS-STRCMP-RETURN        PIC S9(9) COMP-5.
        01  LS-STRCMP-SRC1          PIC X(255).
        01  LS-STRCMP-SRC1-LENGTH   PIC 9(5) COMP-5.
        01  LS-STRCMP-SRC2          PIC X(255).
@@ -33,6 +33,7 @@
                   GOBACK
                END-IF
                ADD 1 TO WS-INDEX
+               END-ADD
            END-PERFORM
             IF LS-STRCMP-SRC1-LENGTH IS GREATER THAN
                 LS-STRCMP-SRC2-LENGTH

--- a/strlen.cob
+++ b/strlen.cob
@@ -18,7 +18,9 @@
                          OR
                          LS-STRLEN-SRC(WS-STRLEN-INDEX:1) = LOW-VALUES
                ADD 1      TO WS-STRLEN-LEN
+               END-ADD
                ADD 1      TO WS-STRLEN-INDEX
+               END-ADD
            END-PERFORM
            MOVE WS-STRLEN-LEN      TO LS-STRLEN-RET
            GOBACK.

--- a/strtrim.cob
+++ b/strtrim.cob
@@ -27,6 +27,7 @@
                   WS-CHAR = WS-LF OR
                   WS-CHAR = WS-CR
                    ADD 1 TO WS-START
+                   END-ADD
                ELSE
                    EXIT PERFORM
                END-IF
@@ -38,7 +39,8 @@
                   WS-CHAR = WS-TAB OR
                   WS-CHAR = WS-LF OR
                   WS-CHAR = WS-CR
-                   SUBTRACT 1 FROM WS-END
+                     SUBTRACT 1 FROM WS-END
+                     END-SUBTRACT
                ELSE
                    EXIT PERFORM
                END-IF
@@ -47,14 +49,17 @@
            MOVE 1 TO WS-DEST-INDEX
            MOVE WS-START TO WS-INDEX
            PERFORM UNTIL WS-INDEX > WS-END
-               MOVE LS-STRTRIM-SRC(WS-INDEX:1)
-                   TO LS-STRTRIM-SRC(WS-DEST-INDEX:1)
+               MOVE LS-STRTRIM-SRC(WS-INDEX:1) TO WS-CHAR
+               MOVE WS-CHAR TO LS-STRTRIM-SRC(WS-DEST-INDEX:1)
                ADD 1 TO WS-INDEX
+               END-ADD
                ADD 1 TO WS-DEST-INDEX
+               END-ADD
            END-PERFORM
 
            PERFORM UNTIL WS-DEST-INDEX > LENGTH OF LS-STRTRIM-SRC
                MOVE WS-SPACE TO LS-STRTRIM-SRC(WS-DEST-INDEX:1)
                ADD 1 TO WS-DEST-INDEX
+               END-ADD
            END-PERFORM
            GOBACK.


### PR DESCRIPTION
## Summary
- align WORKING-STORAGE lines so cobc accepts them
- add missing END-* statements
- copy strings to avoid duplicate reference warnings
- mark comparison return value signed

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6872b8427d2c8331bcb4a30838636cbb